### PR TITLE
docs: define tracking privacy compliance

### DIFF
--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,6 +1,6 @@
 # Privacy Compliance Notes
 
-ClashKing Tracking is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag. Its separate admin API uses revocable administrator sessions and must never accept ClashKingAPI user or integration tokens.
+ClashKing Tracking is a background data collection and processing service. It exposes no user or administrator API, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag. User privacy routes belong to ClashKingAPI; the separate Go administrator API and its revocable Discord sessions belong to ClashKingAdminPanel. Tracking must never accept either API's bearer tokens.
 
 ## Data handled here
 
@@ -23,7 +23,7 @@ Verified access and deletion requests are initiated through the API/dashboard/bo
 
 1. Removing Discord-user keyed preferences from `user_settings`.
 2. Removing or anonymizing Discord-linked player links, reminders, roster references, open tickets, and support records owned by the requester.
-3. Coordinating removal of mobile push/device records from the canonical API data store without exposing a user deletion route from the admin API.
+3. Coordinating removal of mobile push/device records from the canonical API data store without exposing user or administrator routes from the worker.
 4. Preserving public Clash of Clans history only when it is no longer tied to the requester.
 5. Keeping only minimal audit/security evidence required for abuse prevention or legal obligations.
 

--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -7,7 +7,8 @@ ClashKing Tracking is a background data collection and processing service. It ex
 - Clash of Clans player tags, clan tags, names, rankings, war/battle logs, raid data, activity signals, and leaderboard/history snapshots.
 - Server configuration, reminders, user settings, bookmarked players/clans, and account-link dependent processing.
 - Reddit community metadata used by tracking jobs, including author names and avatars where displayed.
-- Operational traces and event streams controlled by `retention_seconds`.
+- Operational event streams, whose Valkey retention is controlled by `retention_seconds`.
+- OpenTelemetry traces, whose retention must be configured and bounded independently in the OTLP backend.
 
 ## Global privacy rules
 

--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,0 +1,34 @@
+# Privacy Compliance Notes
+
+ClashKing Tracking on `feat/golang` is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag.
+
+## Data handled here
+
+- Clash of Clans player tags, clan tags, names, rankings, war/battle logs, raid data, activity signals, and leaderboard/history snapshots.
+- Server configuration, reminders, user settings, bookmarked players/clans, and account-link dependent processing.
+- Reddit community metadata used by tracking jobs, including author names and avatars where displayed.
+- Operational traces and event streams controlled by `retention_seconds`.
+
+## Global privacy rules
+
+- Treat Discord IDs, player-account links, bookmarks, reminders, roster membership, push tokens, and support/ticket references as personal data.
+- Treat public game history as product data only after it is no longer linked to a specific ClashKing or Discord user account.
+- Do not collect advertising IDs, precise location, contacts, health, biometric, or other sensitive categories in this service.
+- Do not log bot tokens, Clash of Clans developer credentials, OAuth tokens, API tokens, push tokens, or raw authorization headers.
+- Keep OpenTelemetry/event-stream retention bounded and aggregate operational telemetry where possible.
+
+## Deletion and export coordination
+
+Verified access and deletion requests are initiated through the API/dashboard/bot surfaces. Tracking jobs must honor those requests by:
+
+1. Removing Discord-user keyed preferences from `user_settings`.
+2. Removing or anonymizing Discord-linked player links, reminders, roster references, open tickets, and support records owned by the requester.
+3. Removing mobile push/device records owned by the requester in the API/admin data stores.
+4. Preserving public Clash of Clans history only when it is no longer tied to the requester.
+5. Keeping only minimal audit/security evidence required for abuse prevention or legal obligations.
+
+Recommended defaults:
+
+- Push tokens: delete immediately on opt-out, logout, account deletion, or invalid-token feedback.
+- Recent searches and event streams: keep short retention windows.
+- Security/audit records: retain for the operational/legal limitation period and mask IP/user-agent fields in exports unless required for investigation.

--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,6 +1,6 @@
 # Privacy Compliance Notes
 
-ClashKing Tracking on `feat/golang` is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag.
+ClashKing Tracking is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag.
 
 ## Data handled here
 

--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,6 +1,6 @@
 # Privacy Compliance Notes
 
-ClashKing Tracking is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag.
+ClashKing Tracking is a background data collection and processing service. It does not expose an authenticated user privacy API itself, but it reads and writes data that can be personal when linked to a Discord account, device, roster, or Clash of Clans player tag. Its separate admin API uses revocable administrator sessions and must never accept ClashKingAPI user or integration tokens.
 
 ## Data handled here
 
@@ -23,7 +23,7 @@ Verified access and deletion requests are initiated through the API/dashboard/bo
 
 1. Removing Discord-user keyed preferences from `user_settings`.
 2. Removing or anonymizing Discord-linked player links, reminders, roster references, open tickets, and support records owned by the requester.
-3. Removing mobile push/device records owned by the requester in the API/admin data stores.
+3. Coordinating removal of mobile push/device records from the canonical API data store without exposing a user deletion route from the admin API.
 4. Preserving public Clash of Clans history only when it is no longer tied to the requester.
 5. Keeping only minimal audit/security evidence required for abuse prevention or legal obligations.
 


### PR DESCRIPTION
## Summary

- documents the privacy obligations of the Tracking data-processing worker
- classifies linked Discord, player, roster, reminder, support, and device data as personal data
- defines deletion/export coordination, retention, logging, and telemetry requirements
- documents the final trust boundary: Tracking exposes no user or administrator API, user privacy routes belong to ClashKingAPI, and the dedicated Go administrator API belongs to ClashKingAdminPanel
- explicitly prevents Tracking from accepting either public API or administrator bearer tokens

## Regulatory coverage

The controls support GDPR/UK GDPR, ePrivacy rules, CCPA/CPRA and other US state privacy laws, PIPEDA, LGPD, Australia Privacy Act, Japan APPI, South Korea PIPA, Singapore PDPA, India DPDP, and applicable child/privacy and platform requirements. Store disclosures, legal texts, and operational request handling remain organization-level obligations.

## Validation

- documentation reviewed against the implemented API and worker ownership boundaries
- branch is based on `feat/golang`